### PR TITLE
Add support for catkin tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ configure_file (
 set(CMAKE_CXX_FLAGS "-std=c++11")
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
-find_package(catkin REQUIRED COMPONENTS roscpp ndt_omp hdl_graph_slam)
+find_package(catkin REQUIRED COMPONENTS roscpp ndt_omp hdl_graph_slam roslib)
 
 find_package(GLM REQUIRED)
 find_package(OpenGL REQUIRED)
@@ -104,6 +104,9 @@ add_executable(odometry2graph
 )
 target_link_libraries(odometry2graph
   ${PCL_LIBRARIES}
+  ${G2O_TYPES_DATA}
+  ${G2O_CORE_LIBRARY}
+  ${G2O_TYPES_SLAM3D}
   ${OPENGL_LIBRARIES}
   ${catkin_LIBRARIES}
   glfw
@@ -137,10 +140,10 @@ target_link_libraries(interactive_slam
   ${G2O_TYPES_SLAM3D}
   ${G2O_TYPES_SLAM3D_ADDONS}
   ${OPENGL_LIBRARIES}
+  ${catkin_LIBRARIES}
   glfw
   guik
   imgui
-  hdl_graph_slam_nodelet
 )
 
 file(COPY data DESTINATION .)

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>ndt_omp</build_depend>
   <build_depend>hdl_graph_slam</build_depend>
+  <build_depend>roslib</build_depend>
   <buildtool_depend>catkin</buildtool_depend>
 
   <export>


### PR DESCRIPTION
I couldn't compile with `catkin-tools` because of several linker errors. My environment is as follows:

- Ubuntu 18.04
- ROS Melodic
- interactive_slam https://github.com/SMRT-AIST/interactive_slam/commit/4616e566795a25b92b2e1f14f34a7a38084591ba
- https://github.com/koide3/hdl_graph_slam/commit/03f93a6832478c635462f1a25f01b4d7f7c765a9
- https://github.com/koide3/ndt_omp/commit/ea2b8f44e6cb3c7b99f99da15776c9db59d4bfc3
- https://github.com/koide3/odometry_saver/commit/87197adf1cc06e558ee4418bc6a3dc176112fc8e

## Steps to reproduce

1. Follow the instructions to install required packages.
2. Execute the following command:

```
$ catkin build -DCMAKE_BUILD_TYPE=Release
```

Some linker errors that I got are:

### `ros::package::getPath`

```
Errors     << interactive_slam:make /home/naoki/ros/workspaces/melodic/slam/logs/interactive_slam/build.make.017.log
CMakeFiles/odometry2graph.dir/src/odometry2graph.cpp.o: In function `hdl_graph_slam::Odometry2GraphApplication::init(char const*, Eigen::Matrix<int, 2, 1, 0, 2, 1> const&, char const*)':
odometry2graph.cpp:(.text._ZN14hdl_graph_slam25Odometry2GraphApplication4initEPKcRKN5Eigen6MatrixIiLi2ELi1ELi0ELi2ELi1EEES2_[_ZN14hdl_graph_slam25Odometry2GraphApplication4initEPKcRKN5Eigen6MatrixIiLi2ELi1ELi0ELi2ELi1EEES2_]+0x1a5): undefined reference to `ros::package::getPath(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
collect2: error: ld returned 1 exit status
make[2]: *** [/home/naoki/ros/workspaces/melodic/slam/devel/.private/interactive_slam/lib/interactive_slam/odometry2graph] Error 1
make[1]: *** [CMakeFiles/odometry2graph.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
/usr/bin/ld: CMakeFiles/interactive_slam.dir/src/interactive_slam.cpp.o: undefined reference to symbol '_ZN3ros7package7getPathERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE'
//opt/ros/melodic/lib/libroslib.so: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [/home/naoki/ros/workspaces/melodic/slam/devel/.private/interactive_slam/lib/interactive_slam/interactive_slam] Error 1
make[1]: *** [CMakeFiles/interactive_slam.dir/all] Error 2
make: *** [all] Error 2
```

### `g2o::VertexSE3::VertexSE3`

```
Errors     << interactive_slam:make /home/naoki/ros/workspaces/melodic/slam/logs/interactive_slam/build.make.001.log
CMakeFiles/odometry2graph.dir/src/odometry2graph.cpp.o: In function `hdl_graph_slam::OdometrySet::save_graph(guik::ProgressInterface&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const':
odometry2graph.cpp:(.text._ZNK14hdl_graph_slam11OdometrySet10save_graphERN4guik17ProgressInterfaceERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZNK14hdl_graph_slam11OdometrySet10save_graphERN4guik17ProgressInterfaceERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0xea): undefined reference to `g2o::VertexSE3::VertexSE3()'
odometry2graph.cpp:(.text._ZNK14hdl_graph_slam11OdometrySet10save_graphERN4guik17ProgressInterfaceERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZNK14hdl_graph_slam11OdometrySet10save_graphERN4guik17ProgressInterfaceERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0x145): undefined reference to `g2o::OptimizableGraph::Vertex::updateCache()'
odometry2graph.cpp:(.text._ZNK14hdl_graph_slam11OdometrySet10save_graphERN4guik17ProgressInterfaceERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZNK14hdl_graph_slam11OdometrySet10save_graphERN4guik17ProgressInterfaceERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0x2e1): undefined reference to `g2o::EdgeSE3::EdgeSE3()'
collect2: error: ld returned 1 exit status
make[2]: *** [/home/naoki/ros/workspaces/melodic/slam/devel/.private/interactive_slam/lib/interactive_slam/odometry2graph] Error 1
make[1]: *** [CMakeFiles/odometry2graph.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
/usr/bin/ld: cannot find -lhdl_graph_slam_nodelet
/usr/bin/ld: cannot find -lhdl_graph_slam_nodelet
collect2: error: ld returned 1 exit status
make[2]: *** [/home/naoki/ros/workspaces/melodic/slam/devel/.private/interactive_slam/lib/interactive_slam/interactive_slam] Error 1
make[1]: *** [CMakeFiles/interactive_slam.dir/all] Error 2
make: *** [all] Error 2
```

### `hdl_graph_slam_nodelet`

```
Errors     << interactive_slam:make /home/naoki/ros/workspaces/melodic/slam/logs/interactive_slam/build.make.009.log
/usr/bin/ld: cannot find -lhdl_graph_slam_nodelet
/usr/bin/ld: cannot find -lhdl_graph_slam_nodelet
collect2: error: ld returned 1 exit status
make[2]: *** [/home/naoki/ros/workspaces/melodic/slam/devel/.private/interactive_slam/lib/interactive_slam/interactive_slam] Error 1
make[1]: *** [CMakeFiles/interactive_slam.dir/all] Error 2
make: *** [all] Error 2
```