### PR TITLE
Avoid misclicking loopend before loop_begin is set

### DIFF
--- a/include/hdl_graph_slam/manual_loop_close_model.hpp
+++ b/include/hdl_graph_slam/manual_loop_close_model.hpp
@@ -25,6 +25,8 @@ public:
 
   bool set_end_keyframe(int keyframe_id);
 
+  bool has_begin_keyframe();
+
   bool run();
 
   void close();

--- a/include/hdl_graph_slam/plane_alignment_modal.hpp
+++ b/include/hdl_graph_slam/plane_alignment_modal.hpp
@@ -23,6 +23,8 @@ public:
   bool set_begin_plane(int plane_id);
   bool set_end_plane(int plane_id);
 
+  bool has_begin_plane();
+
   bool run();
 
   void close();

--- a/src/hdl_graph_slam/manual_loop_close_modal.cpp
+++ b/src/hdl_graph_slam/manual_loop_close_modal.cpp
@@ -53,6 +53,10 @@ bool ManualLoopCloseModal::set_end_keyframe(int keyframe_id) {
   return true;
 }
 
+bool ManualLoopCloseModal::has_begin_keyframe() {
+  return begin_keyframe != nullptr;
+}
+
 void ManualLoopCloseModal::close() {
   begin_keyframe = nullptr;
   end_keyframe = nullptr;

--- a/src/hdl_graph_slam/plane_alignment_modal.cpp
+++ b/src/hdl_graph_slam/plane_alignment_modal.cpp
@@ -41,6 +41,10 @@ bool PlaneAlignmentModal::set_end_plane(int plane_id) {
   return true;
 }
 
+bool PlaneAlignmentModal::has_begin_plane() {
+  return plane_begin != nullptr;
+}
+
 void PlaneAlignmentModal::close() {
   plane_begin = nullptr;
   plane_end = nullptr;

--- a/src/interactive_slam.cpp
+++ b/src/interactive_slam.cpp
@@ -1,5 +1,6 @@
 #include <memory>
 #include <imgui.h>
+#include <imgui_internal.h>
 #include <portable-file-dialogs.h>
 
 #include <glk/lines.hpp>
@@ -643,9 +644,17 @@ private:
           manual_loop_close_modal->set_begin_keyframe(picked_id);
           ImGui::CloseCurrentPopup();
         }
+        if(!manual_loop_close_modal->has_begin_keyframe()){
+          ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
+          ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
+        }
         if(ImGui::Button("Loop end")) {
           manual_loop_close_modal->set_end_keyframe(picked_id);
           ImGui::OpenPopup("manual loop close");
+        }
+        if(!manual_loop_close_modal->has_begin_keyframe()){
+          ImGui::PopItemFlag();
+          ImGui::PopStyleVar();
         }
       }
 
@@ -657,9 +666,17 @@ private:
           plane_alignment_modal->set_begin_plane(picked_id);
           ImGui::CloseCurrentPopup();
         }
+        if(!plane_alignment_modal->has_begin_plane()){
+          ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
+          ImGui::PushStyleVar(ImGuiStyleVar_Alpha, ImGui::GetStyle().Alpha * 0.5f);
+        }
         if(ImGui::Button("Loop end")) {
           plane_alignment_modal->set_end_plane(picked_id);
           ImGui::OpenPopup("plane alignment");
+        }
+        if(!plane_alignment_modal->has_begin_plane()){
+          ImGui::PopItemFlag();
+          ImGui::PopStyleVar();
         }
 
         if(ImGui::BeginMenu("Prior")) {


### PR DESCRIPTION
Avoid #42 by disabling the loop_end button if loop_begin is not set yet. [Reference](https://github.com/ocornut/imgui/issues/211#issuecomment-339241929).

The following pictures show it is not clickable until loop_begin is set
![a](https://user-images.githubusercontent.com/12696742/105218853-a6653180-5b90-11eb-8ea8-037b1b382cb4.png)
![b](https://user-images.githubusercontent.com/12696742/105218859-a7965e80-5b90-11eb-8d19-59a240897861.png)

