### PR TITLE
Make vertex rendering scale changeable 

### DIFF
--- a/data/shader/rainbow.vert
+++ b/data/shader/rainbow.vert
@@ -1,6 +1,8 @@
 #version 330
 uniform float point_size;
 uniform float point_scale;
+uniform bool apply_keyframe_scale;
+uniform float keyframe_scale;
 uniform mat4 model_matrix;
 uniform mat4 view_matrix;
 uniform mat4 projection_matrix;
@@ -44,7 +46,13 @@ vec4 rainbow(vec3 position) {
 }
 
 void main() {
-    vec4 world_position = model_matrix * vec4(vert_position, 1.0);
+    vec4 world_position;
+    if(apply_keyframe_scale){
+        world_position = model_matrix * vec4(keyframe_scale * vert_position, 1.0);
+    }
+    else{
+        world_position = model_matrix * vec4(vert_position, 1.0);
+    }
     frag_world_position = world_position.xyz;
     gl_Position = projection_matrix * view_matrix * world_position;
 

--- a/include/glk/glsl_shader.hpp
+++ b/include/glk/glsl_shader.hpp
@@ -50,6 +50,12 @@ public:
     return mat;
   }
 
+  float get_uniform1f(const std::string& name){
+    float res;
+    glGetUniformfv(shader_program, uniform(name), &res);
+    return res;
+  }
+
   void set_uniform(const std::string& name, int value) { glUniform1i(uniform(name), value); }
   void set_uniform(const std::string& name, float value) { glUniform1f(uniform(name), value); }
   void set_uniform(const std::string& name, const Eigen::Vector2f& vector) { glUniform2fv(uniform(name), 1, vector.data()); }

--- a/include/guik/gl_canvas.hpp
+++ b/include/guik/gl_canvas.hpp
@@ -49,6 +49,7 @@ public:
 
 private:
   float point_size;
+  float keyframe_scale;
   float min_z;
   float max_z;
   bool z_clipping;

--- a/include/hdl_graph_slam/view/keyframe_view.hpp
+++ b/include/hdl_graph_slam/view/keyframe_view.hpp
@@ -45,10 +45,12 @@ public:
     shader.set_uniform("material_color", Eigen::Vector4f(1.0f, 0.0f, 0.0f, 1.0f));
     shader.set_uniform("info_values", Eigen::Vector4i(VERTEX | KEYFRAME, kf->id(), 0, 0));
 
+    shader.set_uniform("apply_keyframe_scale", true);
     model_matrix.block<3, 3>(0, 0) *= 0.35;
     shader.set_uniform("model_matrix", model_matrix);
     const auto& sphere = glk::Primitives::instance()->primitive(glk::Primitives::SPHERE);
     sphere.draw(shader);
+    shader.set_uniform("apply_keyframe_scale", false);
   }
 
   virtual void draw(const DrawFlags& flags, glk::GLSLShader& shader, const Eigen::Vector4f& color, const Eigen::Matrix4f& model_matrix) override {
@@ -68,8 +70,10 @@ public:
 
     shader.set_uniform("color_mode", 1);
     shader.set_uniform("info_values", Eigen::Vector4i(VERTEX | KEYFRAME, kf->id(), 0, 0));
+    shader.set_uniform("apply_keyframe_scale", true);
     const auto& sphere = glk::Primitives::instance()->primitive(glk::Primitives::SPHERE);
     sphere.draw(shader);
+    shader.set_uniform("apply_keyframe_scale", false);
   }
 
 private:

--- a/include/hdl_graph_slam/view/line_buffer.hpp
+++ b/include/hdl_graph_slam/view/line_buffer.hpp
@@ -31,7 +31,8 @@ public:
     shader.set_uniform("color_mode", 2);
     shader.set_uniform("model_matrix", Eigen::Matrix4f::Identity().eval());
 
-    glk::Lines lines(0.1f, vertices, colors, infos);
+    float line_width = 0.1f * shader.get_uniform1f("keyframe_scale");
+    glk::Lines lines(line_width, vertices, colors, infos);
     lines.draw(shader);
   }
 

--- a/src/guik/gl_canvas.cpp
+++ b/src/guik/gl_canvas.cpp
@@ -25,7 +25,7 @@ namespace guik {
  * @param data_directory
  * @param size
  */
-GLCanvas::GLCanvas(const std::string& data_directory, const Eigen::Vector2i& size) : size(size), point_size(50.0f), min_z(-1.5f), max_z(5.0f), z_clipping(true) {
+GLCanvas::GLCanvas(const std::string& data_directory, const Eigen::Vector2i& size) : size(size), point_size(50.0f), keyframe_scale(1.0f), min_z(-1.5f), max_z(5.0f), z_clipping(true) {
   frame_buffer.reset(new glk::FrameBuffer(size));
   frame_buffer->add_color_buffer(GL_RGBA32I, GL_RGBA_INTEGER, GL_INT);
 
@@ -94,6 +94,7 @@ void GLCanvas::bind(bool clear_buffers) {
   shader->set_uniform("color_mode", 0);
   shader->set_uniform("point_scale", 1.0f);
   shader->set_uniform("point_size", point_size);
+  shader->set_uniform("keyframe_scale", keyframe_scale);
 
   glEnable(GL_DEPTH_TEST);
 }
@@ -237,6 +238,7 @@ Eigen::Vector3f GLCanvas::unproject(const Eigen::Vector2i& p, float depth) const
 void GLCanvas::draw_ui() {
   ImGui::Begin("shader setting", nullptr, ImGuiWindowFlags_AlwaysAutoResize);
   ImGui::DragFloat("point_size", &point_size, 10.0f);
+  ImGui::DragFloat("keyframe_scale", &keyframe_scale, 0.1f);
   ImGui::DragFloat("min_z", &min_z, 0.1f);
   ImGui::DragFloat("max_z", &max_z, 0.1f);
   ImGui::Checkbox("z_clipping", &z_clipping);

--- a/src/odometry2graph.cpp
+++ b/src/odometry2graph.cpp
@@ -100,8 +100,10 @@ public:
 
     shader.set_uniform("color_mode", 1);
     shader.set_uniform("material_color", Eigen::Vector4f(1.0f, 0.0f, 0.0f, 1.0f));
+    shader.set_uniform("apply_keyframe_scale", true);
     auto& sphere = glk::Primitives::instance()->primitive(glk::Primitives::SPHERE);
     sphere.draw(shader);
+    shader.set_uniform("apply_keyframe_scale", false);
   }
 private:
   pcl::PointCloud<pcl::PointXYZI>::Ptr load_cloud(const std::string& filename) const {


### PR DESCRIPTION
Addresses this issue #27  by allowing users to adjust keyframe rendering size. Edges are also scaled.
![a](https://user-images.githubusercontent.com/12696742/120838368-519fe180-c59a-11eb-8c92-d6b6e1df3b07.jpg)
![b](https://user-images.githubusercontent.com/12696742/120838385-56fd2c00-c59a-11eb-9454-6d10611bd389.jpg)
![c](https://user-images.githubusercontent.com/12696742/120838390-582e5900-c59a-11eb-83d5-2bcec52a2081.jpg)


