### PR TITLE
Add misisng <boost/filesystem.hpp>

### DIFF
--- a/src/odometry2graph.cpp
+++ b/src/odometry2graph.cpp
@@ -3,6 +3,7 @@
 #include <portable-file-dialogs.h>
 
 #include <boost/format.hpp>
+#include <boost/filesystem.hpp>
 
 #include <pcl/io/pcd_io.h>
 #include <pcl/point_types.h>


### PR DESCRIPTION
Somehow on bleeding edge Arch Linux the absence of `#include <boost/filesystem.hpp>` causes
```
home/toni/.cache/yay/ros-noetic-interactive-slam-git/src/ros-noetic-interactive-slam-git/src/odometry2graph.cpp:246:18: error: ‘boost::filesystem’ has not been declared
  246 |       if(!boost::filesystem::exists(odom_filename)) {
      |                  ^~~~~~~~~~
/home/toni/.cache/yay/ros-noetic-interactive-slam-git/src/ros-noetic-interactive-slam-git/src/odometry2graph.cpp: In member function ‘bool hdl_graph_slam::OdometrySet::save_keyframes(guik::ProgressInterface&, const string&) const’:
/home/toni/.cache/yay/ros-noetic-interactive-slam-git/src/ros-noetic-interactive-slam-git/src/odometry2graph.cpp:367:14: error: ‘boost::filesystem’ has not been declared
  367 |       boost::filesystem::create_directories(keyframe_directory);
      |              ^~~~~~~~~~
/home/toni/.cache/yay/ros-noetic-interactive-slam-git/src/ros-noetic-interactive-slam-git/src/odometry2graph.cpp:369:14: error: ‘boost::filesystem’ has not been declared
  369 |       boost::filesystem::copy_file(keyframes[i]->raw_cloud_path, keyframe_directory + "/raw.pcd");

```
The purpose of this PR is as a patch for Arch User Repository/AUR. As AUR maintainer of this ROS package I must inform the upstream developer about the patch I made. It is okay if this PR is not eventually merged.