### PR TITLE
Add install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,3 +150,13 @@ target_link_libraries(interactive_slam
 )
 
 file(COPY data DESTINATION .)
+
+install(TARGETS
+  interactive_slam
+  odometry2graph
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(DIRECTORY data
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)


### PR DESCRIPTION

The purpose of this PR is as a patch for Arch User Repository/AUR that installed at /opt/ros. Due to that, data and executable need to be declared as install target on  CMakeLists.txt. As AUR maintainer of this ROS package I must inform the upstream developer about the patch I made. It is okay if this PR is not eventually merged.