### PR TITLE
Add fast_gicp to find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ else()
 endif()
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
-find_package(catkin REQUIRED COMPONENTS roscpp ndt_omp hdl_graph_slam roslib)
+find_package(catkin REQUIRED COMPONENTS fast_gicp roscpp ndt_omp hdl_graph_slam roslib)
 
 find_package(GLM REQUIRED)
 find_package(OpenGL REQUIRED)


### PR DESCRIPTION
#69 

When building in Ubuntu 20.04, I got an Error as below.

```bash
Errors     << interactive_slam:make /home/gisen/ros_workspaces/3d_slam_orig/logs/interactive_slam/build.make.003.log
/home/gisen/ros_workspaces/3d_slam_orig/src/interactive_slam/src/hdl_graph_slam/registration_methods.cpp:10:10: fatal error: fast_gicp/gicp/fast_gicp.hpp: No such file or directory
   10 | #include <fast_gicp/gicp/fast_gicp.hpp>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/interactive_slam.dir/build.make:76: CMakeFiles/interactive_slam.dir/src/hdl_graph_slam/registration_methods.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1499: CMakeFiles/interactive_slam.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
```

This PR fix this error.