### PR TITLE
Add missing dependent packages

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,9 @@
   <build_depend>roscpp</build_depend>
   <build_depend>ndt_omp</build_depend>
   <build_depend>hdl_graph_slam</build_depend>
+  <build_depend>libglfw3-dev</build_depend>
+  <build_depend>libglm-dev</build_depend>
+  <build_depend>libg2o</build_depend>
   <build_depend>roslib</build_depend>
   <buildtool_depend>catkin</buildtool_depend>
 


### PR DESCRIPTION
The libraries which use to build the package are missing in `build_depends`.
[libglm-dev](https://github.com/ros/rosdistro/blob/d6969618f1b25e18f21932d19081ac01665234bc/rosdep/base.yaml#L3558-L3564)
[libglfw3-dev](https://github.com/ros/rosdistro/blob/d6969618f1b25e18f21932d19081ac01665234bc/rosdep/base.yaml#L3540-L3549)
So, I added them to `build_depends`.
I would like to remove it from the installation section, but `rosdep install` won't run, so I leave it as is.